### PR TITLE
Strand information is now included in CircSkipJunctions file

### DIFF
--- a/DCC/Circ_nonCirc_Exon_Match.py
+++ b/DCC/Circ_nonCirc_Exon_Match.py
@@ -372,8 +372,7 @@ class CircNonCircExon(object):
                             for j in end:
                                 junctions.setdefault(circ, []).append(itv1.chrom + '\t' +
                                                                       str(int(i) + 1) + '\t'
-                                                                      + j + "\t" +
-                                                                      key.strand)
+                                                                      + j + "\t" + key.strand)
         return junctions
 
     def readSJ_out_tab(self, SJ_out_tab):
@@ -382,8 +381,20 @@ class CircNonCircExon(object):
         try:
             sj = open(SJ_out_tab, 'r')
             for lin in sj:
+
                 lin_split = lin.split('\t')
-                junctionReadCount[lin_split[0] + '\t' + lin_split[1] + '\t' + lin_split[2]] = lin_split[6]
+
+                if lin_split[3] == "1":
+                    strand = "+"
+                elif lin_split[3] == "2":
+                    strand = "-"
+                else:
+                    strand = "?"
+
+                junctionReadCount[lin_split[0] + '\t' +
+                                  lin_split[1] + '\t' +
+                                  lin_split[2] + '\t' +
+                                  strand] = lin_split[6]
             sj.close()
         except IOError:
             print 'Do you have SJ.out.tab files in your sample folder? DCC cannot find it.'
@@ -397,12 +408,10 @@ class CircNonCircExon(object):
             count = []
             for jct in junctions:
                 try:
-                    count.append(jct.split('\t')[0] +
-                                 ':' +
-                                 jct.split('\t')[1] +
-                                 '-' + jct.split('\t')[2] +
-                                 ':' + jct.split('\t')[3] +
-                                 ':' +
+                    count.append(jct.split('\t')[0] + ':' +
+                                 jct.split('\t')[1] + '-' +
+                                 jct.split('\t')[2] +
+                                 jct.split('\t')[3] + ':' +
                                  junctionReadCount[jct])
                 except KeyError:
                     pass

--- a/DCC/Circ_nonCirc_Exon_Match.py
+++ b/DCC/Circ_nonCirc_Exon_Match.py
@@ -370,7 +370,10 @@ class CircNonCircExon(object):
                     if len(start) > 0 and len(end) > 0:
                         for i in start:
                             for j in end:
-                                junctions.setdefault(circ, []).append(itv1.chrom + '\t' + str(int(i) + 1) + '\t' + j)
+                                junctions.setdefault(circ, []).append(itv1.chrom + '\t' +
+                                                                      str(int(i) + 1) + '\t'
+                                                                      + j + "\t" +
+                                                                      key.strand)
         return junctions
 
     def readSJ_out_tab(self, SJ_out_tab):
@@ -394,7 +397,12 @@ class CircNonCircExon(object):
             count = []
             for jct in junctions:
                 try:
-                    count.append(jct.split('\t')[0] + ':' + jct.split('\t')[1] + '-' + jct.split('\t')[2] + ':' +
+                    count.append(jct.split('\t')[0] +
+                                 ':' +
+                                 jct.split('\t')[1] +
+                                 '-' + jct.split('\t')[2] +
+                                 ':' + jct.split('\t')[3] +
+                                 ':' +
                                  junctionReadCount[jct])
                 except KeyError:
                     pass

--- a/DCC/CombineCounts.py
+++ b/DCC/CombineCounts.py
@@ -140,10 +140,10 @@ class Combine(object):
                     #    pass
                     # elif len(line_split) != 5:
                     #    sys.exit("Number of fields in the individual count file is not correct.")
-                    res.setdefault(line_nr, ['\t'.join(line_split[:3])]).append(line_split[col - 1])
+                    res.setdefault(line_nr, ['\t'.join(line_split[:3] + line_split[5])]).append(line_split[col - 1])
 
                 else:  # input are host gene counts
-                    res.setdefault(line_nr, ['\t'.join(line_split[:3])]).append(line_split[col - 1])
+                    res.setdefault(line_nr, ['\t'.join(line_split[:3] + line_split[5])]).append(line_split[col - 1])
 
         return res
 

--- a/DCC/CombineCounts.py
+++ b/DCC/CombineCounts.py
@@ -151,7 +151,7 @@ class Combine(object):
         # Sample list is a string with sample names seperated by \t.
         outfile = open(output, 'w')
         if header:
-            outfile.write('Chr\tStart\tEnd\t' + samplelist + '\n')
+            outfile.write('Chr\tStart\tEnd\tStrand\t' + samplelist + '\n')
         for line_nr in sorted(res):
             outfile.write("%s\n" % '\t'.join(res[line_nr]))
         outfile.close()

--- a/DCC/CombineCounts.py
+++ b/DCC/CombineCounts.py
@@ -140,10 +140,10 @@ class Combine(object):
                     #    pass
                     # elif len(line_split) != 5:
                     #    sys.exit("Number of fields in the individual count file is not correct.")
-                    res.setdefault(line_nr, ['\t'.join(line_split[:3] + line_split[5])]).append(line_split[col - 1])
+                    res.setdefault(line_nr, ['\t'.join(line_split[:3]+[line_split[5]])]).append(line_split[col - 1])
 
                 else:  # input are host gene counts
-                    res.setdefault(line_nr, ['\t'.join(line_split[:3] + line_split[5])]).append(line_split[col - 1])
+                    res.setdefault(line_nr, ['\t'.join(line_split[:3]+[line_split[5]])]).append(line_split[col - 1])
 
         return res
 

--- a/DCC/circFilter.py
+++ b/DCC/circFilter.py
@@ -45,9 +45,9 @@ class Circfilter(object):
             # row_indx = [str(itm) for itm in fields[0:4]]
             # print row_indx
             try:
-                row_count = [int(itm) for itm in fields[3:]]
+                row_count = [int(itm) for itm in fields[4:]]
             except ValueError:
-                row_count = [float(itm) for itm in fields[3:]]
+                row_count = [float(itm) for itm in fields[4:]]
             count.append(row_count)
             # indx.append(row_indx)
 


### PR DESCRIPTION
The `CircSkipJunctions` output file now has a fourth default column that includes the strand of the annotation. Also, all non-zero entries have now the following format: `1:9930458-9935491-:2`, therefore including the strand information before the read count.